### PR TITLE
修复 #587 问题 版本

### DIFF
--- a/studio/modules/service-data-dts-parent/pom.xml
+++ b/studio/modules/service-data-dts-parent/pom.xml
@@ -39,7 +39,7 @@
         <hutool.version>5.4.3</hutool.version>
         <postgresql.version>42.2.5</postgresql.version>
         <mysql-connector.version>5.1.47</mysql-connector.version>
-        <jna.version>4.1.0</jna.version>
+        <jna.version>5.8.0</jna.version>
         <groovy.version>2.5.8</groovy.version>
         <mybatisplus.version>3.3.1</mybatisplus.version>
         <swagger.version>2.9.2</swagger.version>


### PR DESCRIPTION
启动报错
Exception in thread "web, executor ExecutorRegistryThread" java.lang.NoSuchMethodError: com.sun.jna.platform.win32.OleAuto.VariantClear(Lcom/sun/jna/platform/win32/Variant$VARIANT;)Lcom/sun/jna/platform/win32/WinNT$HRESULT;

发现service-data-dts-parent pom文件中 jna.version 版本管理为4.1.0 与项目其他版本不同 变更为5.8.0问题解决