### PR TITLE
#593 系统工具 储存管理 上传报错

### DIFF
--- a/studio/box/src/main/java/com/platform/service/impl/LocalStorageServiceImpl.java
+++ b/studio/box/src/main/java/com/platform/service/impl/LocalStorageServiceImpl.java
@@ -73,7 +73,7 @@ public class LocalStorageServiceImpl implements LocalStorageService {
                     suffix,
                     file.getPath(),
                     type,
-                    FileUtil.getSize(multipartFile.getSize())
+                    FileUtil.getSize(file.length())
             );
             return localStorageRepository.save(localStorage);
         }catch (Exception e){


### PR DESCRIPTION
FileUtil.getSize(multipartFile.getSize()) 中 
multipartFile文件 在方法 file.transferTo(dest); 时 
tmp下文件已经被删除 导致报错
改为 FileUtil.getSize(file.length()) 恢复正常