### PR TITLE
解决datax 本地启动（win环境）不拉取数据

### DIFF
--- a/studio/modules/service-data-dts-parent/service-data-dts/src/main/java/com/platform/admin/core/thread/JobTriggerPoolHelper.java
+++ b/studio/modules/service-data-dts-parent/service-data-dts/src/main/java/com/platform/admin/core/thread/JobTriggerPoolHelper.java
@@ -180,7 +180,11 @@ public class JobTriggerPoolHelper {
 			tmpFilePath = generateTemJsonFile(jobInfo.getJobJson());
 			cmdarrayFinal = buildFlinkXExecutorCmd(ExcecutorConfig.getExcecutorConfig().getFlinkxHome(), tmpFilePath,jobId);
 			for (int j = 0; j < cmdarrayFinal.length; j++) {
-				cmdstr += cmdarrayFinal[j] + " ";
+				if (cmdarrayFinal[j].contains(".out")) {
+					cmdstr += " > " + cmdarrayFinal[j] ;
+				}else {
+					cmdstr += cmdarrayFinal[j] + " ";
+				}
 			}
 			final Process process = Runtime.getRuntime().exec(cmdstr);
 			String prcsId = ProcessUtil.getProcessId(process);


### PR DESCRIPTION
win环境下 data运行命令 输出log 定向 缺少“ > ” 指向 导致命令不运行
对包含.out的命令 增加 > 指向