### PR TITLE
[Fix][studio]在application-common.yml修改mysql驱动类

### DIFF
--- a/studio/config/src/main/resources/config/service-codegen-dev.yml
+++ b/studio/config/src/main/resources/config/service-codegen-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-console-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-console-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-integration-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-integration-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-mapping-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-mapping-dev.yml
@@ -30,7 +30,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-market-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-market-dev.yml
@@ -29,7 +29,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-masterdata-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-masterdata-dev.yml
@@ -30,7 +30,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-metadata-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-metadata-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-quality-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-quality-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-standard-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-standard-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-system-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-system-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-data-visual-dev.yml
+++ b/studio/config/src/main/resources/config/service-data-visual-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-email-dev.yml
+++ b/studio/config/src/main/resources/config/service-email-dev.yml
@@ -31,7 +31,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-file-dev.yml
+++ b/studio/config/src/main/resources/config/service-file-dev.yml
@@ -20,7 +20,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}

--- a/studio/config/src/main/resources/config/service-workflow-dev.yml
+++ b/studio/config/src/main/resources/config/service-workflow-dev.yml
@@ -29,7 +29,7 @@ spring:
       strict: false
       datasource:
         master:
-          driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+          driver-class-name: com.mysql.cj.jdbc.Driver
           url: ${common.mysql.master.url}
           username: ${common.mysql.master.username}
           password: ${common.mysql.master.password}


### PR DESCRIPTION
处理使用MySQL8.0时，config配置项中的驱动写死，导致报错Driver com.p6spy.engine.spy.P6SpyDriver claims to not accept jdbcUrl。